### PR TITLE
Updated raven and added getting DC/OS container details from the env

### DIFF
--- a/girleffect/settings/production.py
+++ b/girleffect/settings/production.py
@@ -36,7 +36,10 @@ _MARATHON_DOCKER_IMAGE = env.get('MARATHON_APP_DOCKER_IMAGE', None)
 _MESOS_TASK_ID = env.get('MESOS_TASK_ID', None)
 if _MARATHON_DOCKER_IMAGE:
     # get the docker image tag
-    _RELEASE_VERSION = _MARATHON_DOCKER_IMAGE.split(':')[1]
+    try:
+        _RELEASE_VERSION = _MARATHON_DOCKER_IMAGE.split(':')[1]
+    except IndexError:
+        _RELEASE_VERSION = raven.fetch_git_sha(BASE_DIR)
 else:
     _RELEASE_VERSION = raven.fetch_git_sha(BASE_DIR)
 if _MESOS_TASK_ID:

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,5 +21,5 @@ dj-database-url==0.4.1
 whitenoise==2.0.4
 uwsgi==2.0.15
 ConcurrentLogHandler==0.9.1
-raven==6.1.0
+raven==6.6.0
 django-cache-url==1.3.1


### PR DESCRIPTION
Updated raven and added getting DC/OS container details from the env and passing them to Raven. This will help isolate errors to specific versions and containers from within Sentry.