### PR TITLE
Remove the extra slash from the BASE_URL

### DIFF
--- a/girleffect/settings/production.py
+++ b/girleffect/settings/production.py
@@ -71,7 +71,7 @@ if 'ALLOWED_HOSTS' in env:
     ALLOWED_HOSTS = env['ALLOWED_HOSTS'].split(',')
 
 if 'PRIMARY_HOST' in env:
-    BASE_URL = 'http://%s/' % env['PRIMARY_HOST']
+    BASE_URL = 'http://%s' % env['PRIMARY_HOST']
 
 if 'SERVER_EMAIL' in env:
     SERVER_EMAIL = env['SERVER_EMAIL']


### PR DESCRIPTION
Currently the resent password link sent in the email has an extra slash after the domain which it's preventing the admin users from reseting their password. 
Current Link: `http://girleffect.org//admin/password_reset/confirm/MQ/4zd-092f6db9c6245fe7b348/`

Removing the extra `/` from the BASE_URL should resolve the issue.