### PR TITLE
Add django.contrib.sitemaps to installed apps

### DIFF
--- a/girleffect/settings/base.py
+++ b/girleffect/settings/base.py
@@ -75,6 +75,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.sitemaps',
 ]
 
 if OIDC_ENABLED:


### PR DESCRIPTION
currently the `/sitemaps.xml` page returns a 404. I'm hoping this will fix that.
Although the wagtail version of the sitemaps app is already installed so /shrug