### PR TITLE
Set hsts header to expire after 1 hour

### DIFF
--- a/girleffect/settings/production.py
+++ b/girleffect/settings/production.py
@@ -65,7 +65,7 @@ if env.get('SECURE_SSL_REDIRECT', 'true') == 'true':
     SECURE_SSL_REDIRECT = True
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 # enable HSTS only once the site is working properly on https with the actual live domain name
-# SECURE_HSTS_SECONDS = 31536000  # 1 year
+SECURE_HSTS_SECONDS = 3600  # 1 hour
 
 if 'SECRET_KEY' in env:
     SECRET_KEY = env['SECRET_KEY']


### PR DESCRIPTION
Tells Django security middleware to set the http strict transport security header to be valid for 1hr.
This means that any non-https requests will fail until an hour has passed and they are retried.
This is set low for now so that we can address any resources that might not be served via https at the moment.