### PR TITLE
Add nginx config to redirect www requests to nonwww

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main" > /etc/
 WORKDIR /app
 ENV PYTHONPATH /app
 
+COPY site-redir-www-nonwww.conf /etc/nginx/conf.d/site-redir-www-nonwww.conf
+
 # Install requirements - done in a separate step so Docker can cache it.
 COPY requirements.txt /
 RUN pip install -r /requirements.txt

--- a/site-redir-www-nonwww.conf
+++ b/site-redir-www-nonwww.conf
@@ -1,0 +1,14 @@
+# redirect all requests with the prefix www. to the site without www
+# Sets a $real_scheme variable whose value is the scheme passed by the load
+# balancer in X-Forwarded-Proto (if any), defaulting to $scheme.
+# Similar to how the HttpRealIp module treats X-Forwarded-For.
+map $http_x_forwarded_proto $real_scheme {
+  default $http_x_forwarded_proto;
+  ''      $scheme;
+}
+# redirect all requests with the prefix www. to the site without www
+server {
+    listen 8000;
+    server_name ~^www\.(?<domain>.+)$;
+    return 301 $real_scheme://$domain$request_uri;
+}


### PR DESCRIPTION
This will ensure that requests to "http://www.domain/something" get redirected to "http://domain/something"
At the moment "something" is getting stripped from the request on the redirect