### PR TITLE
Fix the admin user check for if they have user delete permissions

### DIFF
--- a/girleffect/templates/wagtailusers/users/edit.html
+++ b/girleffect/templates/wagtailusers/users/edit.html
@@ -30,7 +30,7 @@
                     {% endblock fields %}
                     <li>
                         <input type="submit" value="{% trans 'Save' %}" class="button" />
-                        {% if can_delete %}
+                        {% if perms.auth.delete_user %}
                             <a href="{% url 'wagtailusers_users:delete' user.pk %}" class="button button-secondary no">{% trans "Delete user" %}</a>
                         {% endif %}
                     </li>
@@ -45,7 +45,7 @@
                     {% include "wagtailadmin/shared/field_as_li.html" with field=form.groups %}
                     <li>
                         <input type="submit" value="{% trans 'Save' %}" class="button" />
-                        {% if can_delete %}
+                        {% if perms.auth.delete_user %}
                             <a href="{% url 'wagtailusers_users:delete' user.pk %}" class="button button-secondary no">{% trans "Delete user" %}</a>
                         {% endif %}
                     </li>


### PR DESCRIPTION
I added a delete button to the user edit page (because some admins were looking for it there) but I used the wrong permissions check. This fixes that