### PR TITLE
Add active flag to user edit page

### DIFF
--- a/girleffect/templates/wagtailusers/users/edit.html
+++ b/girleffect/templates/wagtailusers/users/edit.html
@@ -25,6 +25,9 @@
                         {% include "wagtailadmin/shared/field_as_li.html" with field=form.email %}
                         {% include "wagtailadmin/shared/field_as_li.html" with field=form.first_name %}
                         {% include "wagtailadmin/shared/field_as_li.html" with field=form.last_name %}
+                        {% if form.is_active %}
+                            {% include "wagtailadmin/shared/field_as_li.html" with field=form.is_active %}
+                        {% endif %}
                         {% block extra_fields %}{% endblock extra_fields %}
 
                     {% endblock fields %}


### PR DESCRIPTION
Currently when you save changes to a user the user is set to "inactive". This is because the "is_active" flag is a checkbox and if a checkbox isn't present in the form data then it sets the value to false.
This change adds the checkbox to the form so that it is present when the form is saved.
This matches the default wagtail admin implementation https://github.com/wagtail/wagtail/blob/master/wagtail/users/templates/wagtailusers/users/edit.html#L36