### PR TITLE
If CACHE_URL env var is empty don't use it

### DIFF
--- a/girleffect/settings/production.py
+++ b/girleffect/settings/production.py
@@ -155,8 +155,9 @@ else:
 
 
 # Redis
-
-if 'CACHE_URL' in env:
+# django_cache_url defaults to memcache
+CACHE_URL = env.get('CACHE_URL', "")
+if 'CACHE_URL':
     CACHES = {'default': django_cache_url.config()}
 
 


### PR DESCRIPTION
This is required to be able to run the application on Divio